### PR TITLE
Raise correct exception when element is not found

### DIFF
--- a/veripy/steps/text.py
+++ b/veripy/steps/text.py
@@ -35,6 +35,9 @@ def check_element_visible(context, element, not_):
             f'The element "{element}" was supposed to be visible and was not.'
         )
     except context.page.ElementNotFound:
+        if not not_:
+            raise
+
         assert not_, (
             f'The element "{element}" was not supposed to be visible and was.'
         )


### PR DESCRIPTION
Previously, if the element was not found in the page when it was
expected to be visible, the sentence would incorrectly raise the
exception that the element was expected to not be visisble but it was.

This fix correctly observes the `not_` parameter when the element is not
found on the page.

## Additions

NA

## Removals

NA

## Changes

- Correct behavior of `check_element_visible` 

## Screenshots

NA

## Notes

- `check_element_visisble` still checks if the element is visible, which uses up all of the retry time, before resorting to "not" behavior

## Todos

NA

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code is rebased
- [x] Code follows the existing coding style guide
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Project documentation has been updated
- [x] Visually tested in supported browsers and devices (if applicable)

