### PR TITLE
Adds purposefully failing tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - flake8
   - make -C docs html
   # TODO: Optimize this command. It's wonky right now.
-  - FIXTURES_DIR=example/fixtures RESOURCES_DIR=`pwd`/example/resources REPORTS_DIR=example/report behave example/features
+  - FIXTURES_DIR=example/fixtures RESOURCES_DIR=`pwd`/example/resources REPORTS_DIR=example/report behave example/features --tags ~@xfail
 
 # TODO: We don't have coveralls yet.
 # after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: xenial
 python:
   - '3.6'
   - "3.7"
-  - "3.8-dev"
+  # - "3.8-dev"
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ source environment.sh
 VeriPy is built on Behave. As such any files ending in `.feature` inside of the `features/` directory will be run when the application starts. VeriPy comes with a sample set of tests demonstrating how to use the statements. To run these or any custom tests, use the following command:
 
 ```bash
-behave example/features/
+behave example/features/ --tags ~@xfail
 ```
 
 To identify where sentences are used (and which are undefined), use the dry-run mode to

--- a/example/features/content.feature
+++ b/example/features/content.feature
@@ -22,6 +22,18 @@ Feature: Content Sentences
              """
         Then take a screen shot
 
+    @example_app @content @checks @element_contains_text @xfail
+    Scenario: XFail: The Demo App header does not contain the text "Goodbye World"
+        Given that the browser is at "localhost-hello"
+        Then the "Page Header" contains the text "Goodbye World"
+        Then take a screen shot
+
+    @example_app @content @checks @element_contains_text @xfail
+    Scenario: XFail: The Demo App header does not contain the Missing Link
+        Given that the browser is at "localhost-hello"
+        Then the "Missing Link" contains the text "Goodbye World"
+        Then take a screen shot
+
 
     @example_app @content @checks @element_visible
     Scenario: The Demo App header is visible and the Hidden Content is not
@@ -51,6 +63,23 @@ Feature: Content Sentences
              """
         Then take a screen shot
 
+    @example_app @content @checks @element_visible @xfail
+    Scenario: XFail: The visibility check responds for visible objects
+        Given that the browser is at "localhost-hello"
+        Then the "Page Header" is not visible
+        Then take a screen shot
+
+    @example_app @content @checks @element_visible @xfail
+    Scenario: XFail: The visibility check responds for invisible objects
+        Given that the browser is at "localhost-hello"
+        Then the "Hidden Content" is visible
+        Then take a screen shot
+
+    @example_app @content @checks @element_visible @xfail
+    Scenario: XFail: The visibility check responds for missing objects
+        Given that the browser is at "localhost-hello"
+        Then the "Missing Link" is visible
+        Then take a screen shot
 
     @example_app @content @checks @nth_element_contains_text
     Scenario: The Nth item sentence finds the correct item and asserts its text
@@ -77,6 +106,23 @@ Feature: Content Sentences
             """
         Then take a screen shot
 
+    @example_app @content @checks @nth_element_contains_text @xfail
+    Scenario: Xfail: The Nth item sentence responds with missing input
+        Given that the browser is at "localhost-hello"
+        Then the 2nd label in the "form" contains the text "Required input"
+        Then take a screen shot
+
+    @example_app @content @checks @nth_element_contains_text @xfail
+    Scenario: Xfail: The Nth item sentence responds with not enough inputs
+        Given that the browser is at "localhost-hello"
+        Then the 99th label in the "form" contains the text "Required input"
+        Then take a screen shot
+
+    @example_app @content @checks @nth_element_contains_text @xfail
+    Scenario: Xfail: The Nth item sentence responds with not found
+        Given that the browser is at "localhost-hello"
+        Then the 1st word in the "Missing Link" contains the text "Not"
+        Then take a screen shot
 
     @example_app @content @checks @page_title
     Scenario: The Demo App Page Title is "Hello World"
@@ -93,4 +139,10 @@ Feature: Content Sentences
           """
           The page title was supposed to be "Goodbye World" but was "Hello World".
           """
+        Then take a screen shot
+
+    @example_app @content @checks @page_title @xfail
+    Scenario: XFail: The Demo App Page Title is not "Goodbye World"
+        Given that the browser is at "localhost-hello"
+        Then the page title should be "Goodbye World"
         Then take a screen shot

--- a/example/features/forms.feature
+++ b/example/features/forms.feature
@@ -19,6 +19,12 @@ Feature: Form Sentences
             The "Missing Field" was not found on the page.
             """
 
+    @example_app @forms @actions @clear_input @xfail
+    Scenario: XFail: The clear input sentence handles the input not being found
+        Given that the browser is at "localhost-hello"
+        When the user clears the "Missing Field"
+        Then take a screen shot
+
     @example_app @forms @actions @enter_input_from_file
     Scenario: The Demo App form field can be entered from a file
         Given that the browser is at "localhost-hello"
@@ -42,6 +48,17 @@ Feature: Form Sentences
             The specified file does not exist.
             """
 
+    @example_app @forms @actions @enter_input_from_file @xfail
+    Scenario: XFail: The file entry sentence handles missing form fields
+        Given that the browser is at "localhost-hello"
+        When the content from "copyable-file.txt" is entered into the "Missing Field"
+        Then take a screen shot
+
+    @example_app @forms @actions @enter_input_from_file @xfail
+    Scenario: XFail: The file entry sentence handles missing files
+        Given that the browser is at "localhost-hello"
+        When the content from "missing-file.txt" is entered into the "Textarea Field"
+        Then take a screen shot
 
     @example_app @forms @actions @enter_text_into_current
     Scenario: The tester can press keyboard keys
@@ -77,6 +94,23 @@ Feature: Form Sentences
             The "Missing Field" was not found on the page.
             """
 
+    @example_app @forms @actions @enter_text_into_field @xfail
+    Scenario: XFail: The system responds for disabled fields
+        Given that the browser is at "localhost-hello"
+        When "Example Text" is entered into the "Disabled Field"
+        Then take a screen shot
+
+    @example_app @forms @actions @enter_text_into_field @xfail
+    Scenario: XFail: The system responds for non fields
+        Given that the browser is at "localhost-hello"
+        When "Example Text" is entered into the "Other Page Link"
+        Then take a screen shot
+
+    @example_app @forms @actions @enter_text_into_field @xfail
+    Scenario: XFail: The system responds for missing fields
+        Given that the browser is at "localhost-hello"
+        When "Example Text" is entered into the "Missing Field"
+        Then take a screen shot
 
     @example_app @forms @actions @select_option
     Scenario: A select field can have an option selected
@@ -98,6 +132,18 @@ Feature: Form Sentences
           The "Missing Field" was not found on the page.
           """
 
+    @example_app @forms @actions @select_option @xfail
+    Scenario: XFail: The system responds when there is no option
+        Given that the browser is at "localhost-hello"
+        When "yellow" is selected for "Select Field"
+        Then take a screen shot
+
+
+    @example_app @forms @actions @select_option @xfail
+    Scenario: XFail: The system responds when there is no field
+        Given that the browser is at "localhost-hello"
+        When "green" is selected for "Missing Field"
+        Then take a screen shot
 
     @example_app @forms @actions @upload_file_to_field
     Scenario: A file can be uploaded to a field
@@ -122,6 +168,17 @@ Feature: Form Sentences
             The specified file does not exist.
             """
 
+    @example_app @forms @actions @upload_file_to_field @xfail
+    Scenario: XFail: The file upload sentence handles missing form fields
+        Given that the browser is at "localhost-hello"
+        When the file "uploadable-file.txt" has been added to the "Missing Field"
+        Then take a screen shot
+
+    @example_app @forms @actions @upload_file_to_field @xfail
+    Scenario: XFail: The file upload sentence handles missing files
+        Given that the browser is at "localhost-hello"
+        When the file "missing-file.txt" has been added to the "File Upload Field"
+        Then take a screen shot
 
     @example_app @forms @checks @field_accepts_type
     Scenario: The fields can accept certain types of data
@@ -149,6 +206,20 @@ Feature: Form Sentences
             The "Missing Field" was not found on the page.
             """
 
+    @example_app @forms @checks @field_accepts_type @xfail
+    Scenario: XFail: The check that fields can accept text
+        Given that the browser is at "localhost-hello"
+        Then the "Text Field" field does not accept text
+
+    @example_app @forms @checks @field_accepts_type @xfail
+    Scenario: XFail: The check that fields can accept numbers
+        Given that the browser is at "localhost-hello"
+        Then the "Text Field" field does accept numbers
+
+    @example_app @forms @checks @field_accepts_type @xfail
+    Scenario: XFail: The check that fields can accept numbers
+        Given that the browser is at "localhost-hello"
+        Then the "Missing Field" field does accept text
 
     @example_app @forms @checks @field_disabled
     Scenario: The fields can be enabled or disabled
@@ -174,6 +245,20 @@ Feature: Form Sentences
             The "Missing Field" was not found on the page.
             """
 
+    @example_app @forms @checks @field_disabled @xfail
+    Scenario: XFail: The check that fields are enabled
+        Given that the browser is at "localhost-hello"
+        Then the "Enabled Field" field is not enabled
+
+    @example_app @forms @checks @field_disabled @xfail
+    Scenario: XFail: The check that fields are disabled
+        Given that the browser is at "localhost-hello"
+        Then the "Disabled Field" field is enabled
+
+    @example_app @forms @checks @field_disabled @xfail
+    Scenario: XFail: The check that fields are present
+        Given that the browser is at "localhost-hello"
+        Then the "Missing Field" field is enabled
 
     @example_app @forms @checks @field_required
     Scenario: The fields can be required or optional
@@ -200,3 +285,22 @@ Feature: Form Sentences
             """
             The "Missing Field" was not found on the page.
             """
+
+    @example_app @forms @checks @field_required @xfail
+    Scenario: Xfail: The check that fields are required
+        Given that the browser is at "localhost-hello"
+        Then the "Required Field" field is not required
+
+    @example_app @forms @checks @field_required @xfail
+    Scenario: Xfail: The check that fields are not required
+        Given that the browser is at "localhost-hello"
+        Then the "Optional Field" field is required
+        Then the statement that 'the "Missing Field" field is required' responds with
+            """
+            The "Missing Field" was not found on the page.
+            """
+
+    @example_app @forms @checks @field_required @xfail
+    Scenario: Xfail: The check that fields are present
+        Given that the browser is at "localhost-hello"
+        Then the "Missing Field" field is required

--- a/example/features/navigation.feature
+++ b/example/features/navigation.feature
@@ -44,14 +44,11 @@ Feature: Navigation Sentences
       """
     Then take a screen shot
 
-    Scenario: The Demo App option can be selected by position
+    @example_app @navigation @actions @click_element @xfail
+    Scenario: XFail: The Demo App page will raise the correct error when clicking on a missing element
     Given that the browser is at "localhost-hello"
-    Then if 'the user clicks the "Missing Link"', the system responds with
-      """
-      The "Missing Link" was not found on the page.
-      """
+    When the user clicks the "Missing Link"
     Then take a screen shot
-
 
     @example_app @navigation @actions @click_nth_element
     Scenario: The Nth item sentence finds the correct item clicks it
@@ -102,4 +99,11 @@ Feature: Navigation Sentences
             Expected to be on the Page "login", but was not.
             """
         Then the browser should be at "other-page"
+        Then take a screen shot
+
+    @example_app @navigation @checks @browser_at_page @xfail
+    Scenario: XFail: Test that the user can identify failed page context switches
+        Given that the browser is at "localhost-hello"
+        When the user clicks the "Other Page Link"
+        Then the browser should be at "login"
         Then take a screen shot


### PR DESCRIPTION
 that can be omitted via `--tags ~@xfail` command

This change allows us to verify that our tests do indeed fail when they are supposed to fail, and have the appropriate data associated with it
## Additions

-

## Removals

-

## Changes

-

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [/] PR has an informative and human-readable title
- [/] Changes are limited to a single goal (no scope creep)
- [/] Code is rebased
- [/] Code follows the existing coding style guide
- [/] Passes all existing automated tests
- [/] Any _change_ in functionality is tested
- [/] New functions are documented (with a description, list of inputs, and expected output)
- [/] Project documentation has been updated
- [/] Visually tested in supported browsers and devices (if applicable)

