### PR TITLE
Implment browser tab switching

### DIFF
--- a/docs/step_definitions/index.rst
+++ b/docs/step_definitions/index.rst
@@ -21,6 +21,7 @@ The following step definitions are provided here.
     step_module.veripy.steps.capture.capture_content
     step_module.veripy.steps.capture.capture_screenshot
     step_module.veripy.steps.content.checks.element_contains_text
+    step_module.veripy.steps.content.checks.element_not_contains_text
     step_module.veripy.steps.content.checks.element_visible
     step_module.veripy.steps.content.checks.nth_element_contains_text
     step_module.veripy.steps.forms.actions.clear_input
@@ -42,6 +43,8 @@ The following step definitions are provided here.
     step_module.veripy.steps.navigation.actions.press_keyboard_key
     step_module.veripy.steps.navigation.actions.wait_for_element
     step_module.veripy.steps.navigation.actions.wait_time
+    step_module.veripy.steps.navigation.actions.window_close_last
+    step_module.veripy.steps.navigation.actions.window_focus_last
     step_module.veripy.steps.navigation.checks.browser_at_page
     step_module.veripy.utils
 

--- a/docs/step_definitions/step_module.veripy.steps.content.checks.element_not_contains_text.rst
+++ b/docs/step_definitions/step_module.veripy.steps.content.checks.element_not_contains_text.rst
@@ -1,0 +1,33 @@
+.. _docid.steps.veripy.steps.content.checks.element_not_contains_text:
+.. index:: veripy.steps.content.checks.element_not_contains_text
+
+======================================================================
+veripy.steps.content.checks.element_not_contains_text
+======================================================================
+
+:Module:   veripy.steps.content.checks.element_not_contains_text
+:Filename: veripy/steps/content/checks/element_not_contains_text.py
+
+Step Overview
+=============
+
+
+======================================================= ===== ==== ==== ====
+Step Definition                                         Given When Then Step
+======================================================= ===== ==== ==== ====
+Then the "{element}" does not contain the text "{text}"              x      
+======================================================= ===== ==== ==== ====
+
+Step Definitions
+================
+
+.. index:: 
+    single: Then step; Then the "{element}" does not contain the text "{text}"
+
+.. _then the "{element}" does not contain the text "{text}":
+
+**Step:** Then the "{element}" does not contain the text "{text}"
+-----------------------------------------------------------------
+
+Asserts that the element does not contain the given value as text.
+

--- a/docs/step_definitions/step_module.veripy.steps.navigation.actions.window_close_last.rst
+++ b/docs/step_definitions/step_module.veripy.steps.navigation.actions.window_close_last.rst
@@ -1,0 +1,36 @@
+.. _docid.steps.veripy.steps.navigation.actions.window_close_last:
+.. index:: veripy.steps.navigation.actions.window_close_last
+
+======================================================================
+veripy.steps.navigation.actions.window_close_last
+======================================================================
+
+:Module:   veripy.steps.navigation.actions.window_close_last
+:Filename: veripy/steps/navigation/actions/window_close_last.py
+
+Step Overview
+=============
+
+
+============================================= ===== ==== ==== ====
+Step Definition                               Given When Then Step
+============================================= ===== ==== ==== ====
+When the user closes the last opened {screen}         x           
+============================================= ===== ==== ==== ====
+
+Step Definitions
+================
+
+.. index:: 
+    single: When step; When the user closes the last opened {screen}
+
+.. _when the user closes the last opened {screen}:
+
+**Step:** When the user closes the last opened {screen}
+-------------------------------------------------------
+
+Tells the browser to close was most recently openened
+::
+
+    When the use closes the last opened tab
+

--- a/docs/step_definitions/step_module.veripy.steps.navigation.actions.window_focus_last.rst
+++ b/docs/step_definitions/step_module.veripy.steps.navigation.actions.window_focus_last.rst
@@ -1,0 +1,36 @@
+.. _docid.steps.veripy.steps.navigation.actions.window_focus_last:
+.. index:: veripy.steps.navigation.actions.window_focus_last
+
+======================================================================
+veripy.steps.navigation.actions.window_focus_last
+======================================================================
+
+:Module:   veripy.steps.navigation.actions.window_focus_last
+:Filename: veripy/steps/navigation/actions/window_focus_last.py
+
+Step Overview
+=============
+
+
+================================================== ===== ==== ==== ====
+Step Definition                                    Given When Then Step
+================================================== ===== ==== ==== ====
+When the user switches to the last opened {screen}         x           
+================================================== ===== ==== ==== ====
+
+Step Definitions
+================
+
+.. index:: 
+    single: When step; When the user switches to the last opened {screen}
+
+.. _when the user switches to the last opened {screen}:
+
+**Step:** When the user switches to the last opened {screen}
+------------------------------------------------------------
+
+Tells the browser to switch to the tab that was most recently openened
+::
+
+    When the use switches to the last opened tab
+

--- a/example/features/navigation.feature
+++ b/example/features/navigation.feature
@@ -23,6 +23,29 @@ Feature: Navigation Sentences
         Then the "Other Random Number" is not visible
         Then take a screen shot
 
+    @example_app @navigation @actions @window_focus_last
+    Scenario: The Demo App tab can be switched by clicking a link
+        Given that the browser is at "localhost-hello"
+        When the user clicks the "Other Tab Link"
+        Then the browser should be at "localhost-hello"
+
+        When the user switches to the last opened tab
+        Then the browser should be at "other-page"
+        And take a screen shot
+
+    @example_app @navigation @actions @window_close_last
+    Scenario: The Demo App tab can be switched by clicking a link and then reverted
+        Given that the browser is at "localhost-hello"
+        When the user clicks the "Other Tab Link"
+        Then the browser should be at "localhost-hello"
+
+        When the user switches to the last opened tab
+        Then the browser should be at "other-page"
+
+        When the user closes the last opened tab
+        Then the browser should be at "localhost-hello"
+        And take a screen shot
+
     @example_app @navigation @actions @click_element
     Scenario: The Demo App page can be switched by clicking a link
 

--- a/example/fixtures/localhost-hello.json
+++ b/example/fixtures/localhost-hello.json
@@ -87,6 +87,10 @@
       "by": "id",
       "selector": "other-page-link"
     },
+    "Other Tab Link": {
+      "by": "id",
+      "selector": "other-tab-link"
+    },
     "form": {
       "by": "css",
       "selector": "form label",

--- a/example/sampleapp/index.html
+++ b/example/sampleapp/index.html
@@ -91,6 +91,11 @@
               Link to another page
               <a href="/other-page.html" id="other-page-link">Go to Other Page &#8594;</a>
             </label><br />
+
+            <label>
+              Link to another tab
+              <a href="/other-page.html" id="other-tab-link" target="_blank">Go to Other Tab&#8594;</a>
+            </label><br />
         </div>
     </body>
 

--- a/veripy/steps/navigation/__init__.py
+++ b/veripy/steps/navigation/__init__.py
@@ -6,6 +6,8 @@ from .actions.click_nth_element import * # noqa
 from .actions.press_keyboard_key import * # noqa
 from .actions.wait_for_element import * # noqa
 from .actions.wait_time import * # noqa
+from .actions.window_close_last import * # noqa
+from .actions.window_focus_last import * # noqa
 from .checks.browser_at_page import * # noqa
 
 
@@ -18,5 +20,7 @@ __all__ = [
     'when_press_key',
     'when_wait_for_element',
     'when_wait',
-    'then_page_switch'
+    'window_close_last',
+    'window_focus_last',
+    'then_page_switch',
 ]

--- a/veripy/steps/navigation/actions/window_close_last.py
+++ b/veripy/steps/navigation/actions/window_close_last.py
@@ -1,0 +1,19 @@
+import logging
+from behave import when
+
+logger = logging.getLogger('navigation')
+
+
+@when('the user closes the last opened {screen}')
+def window_close_last(context, screen):
+    """ Tells the browser to close was most recently openened
+    ::
+
+        When the use closes the last opened tab
+    """
+
+    if screen not in ('window', 'tab'):
+        raise Exception('Must specify either window or tab')
+
+    context.browser.windows.current = context.browser.windows[0]
+    context.browser.windows[-1].close()

--- a/veripy/steps/navigation/actions/window_focus_last.py
+++ b/veripy/steps/navigation/actions/window_focus_last.py
@@ -1,0 +1,18 @@
+import logging
+from behave import when
+
+logger = logging.getLogger('navigation')
+
+
+@when('the user switches to the last opened {screen}')
+def window_focus_last(context, screen):
+    """ Tells the browser to switch to the tab that was most recently openened
+    ::
+
+        When the use switches to the last opened tab
+    """
+
+    if screen not in ('window', 'tab'):
+        raise Exception('Must specify either window or tab')
+
+    context.browser.windows.current = context.browser.windows[-1]


### PR DESCRIPTION
This change implements the necessary steps to manipulate the browser
tab in the case where a link in the form of `<a target="_blank"...>`
is clicked.

## Additions

- Implement sentence to switch to the last opened tab
- Implement sentence to close the last opened tab and return to the first tab

## Removals

NA

## Changes

NA

## Screenshots

NA

## Notes

NA

## Todos

NA

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code is rebased
- [x] Code follows the existing coding style guide
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Project documentation has been updated
- [x] Visually tested in supported browsers and devices (if applicable)

