### PR TITLE
Fixes to how select options are found.

### DIFF
--- a/example/features/forms.feature
+++ b/example/features/forms.feature
@@ -160,6 +160,25 @@ Feature: Form Sentences
         Given that the browser is at "localhost-hello"
         When "yellow" is selected for "Select Field"
 
+    @example_app @forms @actions @select_option
+    Scenario: A nameless select field can have an option selected
+        Given that the browser is at "localhost-hello"
+        When "green" is selected for "Nameless Select Field"
+        Then the "Nameless Select Field" has the value "green"
+
+
+    @example_app @forms @actions @select_option @exceptions
+    Scenario: The system responds correctly when a nameless select field can have not an option selected
+        Given that the browser is at "localhost-hello"
+        Then if '"yellow" is selected for "Nameless Select Field"', the system responds with
+          """
+          "Nameless Select Field" has no option with value "yellow".
+          """
+
+    @example_app @forms @actions @select_option @xfail
+    Scenario: XFail: The system responds when there is no option on a nameless select
+        Given that the browser is at "localhost-hello"
+        When "yellow" is selected for "Nameless Select Field"
 
     @example_app @forms @actions @select_option @xfail
     Scenario: XFail: The system responds when there is no field

--- a/example/fixtures/localhost-hello.json
+++ b/example/fixtures/localhost-hello.json
@@ -75,6 +75,10 @@
       "by": "name",
       "selector": "select-field"
     },
+    "Nameless Select Field": {
+      "by": "xpath",
+      "selector": "//*[@id=\"nameless-select-field\"]"
+    },
     "Missing Field": {
       "by": "id",
       "selector": "a-field-that-is-not-on-the-page"

--- a/example/sampleapp/index.html
+++ b/example/sampleapp/index.html
@@ -80,6 +80,15 @@
                 </select>
               </label>
               <br />
+              <label>
+                Nameless Select input
+                <select id="nameless-select-field">
+                  <option value="red">Red Color</option>
+                  <option value="green">Green Color</option>
+                  <option value="blue">Blue Color</option>
+                </select>
+              </label>
+              <br />
             </form>
 
             <label>

--- a/veripy/exceptions.py
+++ b/veripy/exceptions.py
@@ -1,0 +1,7 @@
+class ImproperlyConfigured(Exception):
+    """ Raised when some part of the VeriPy application is improperly configured.
+    This could be that the page fixtures are invalid, or that the application
+    cannot reasonably make judgements about the specified environment variables,
+    or if the application is configured multiple times in a conflicting manner.
+    """
+    pass

--- a/veripy/pages/base.py
+++ b/veripy/pages/base.py
@@ -182,7 +182,6 @@ class Page(object):
         """
         return getattr(self._elements, name)
 
-
     @allow_retries(retry_on=(ElementNotFound,), retries=1)
     def find(self, selector, by='id', allow_multiple=False, **kwargs):
         """ Given a method and a selector, attempt to find the given element

--- a/veripy/pages/base.py
+++ b/veripy/pages/base.py
@@ -103,7 +103,7 @@ class Page(object):
         logger.info(f'Finished initializing page: "{name}"')
 
     def __getitem__(self, name):
-        property = getattr(self._elements, name)
+        property = self.get_element_properties(name)
         return self.find(property['selector'], property['by'], **property.get('kwargs', {}))
 
     def _find_selectors(self, by='id', parent=None):
@@ -167,6 +167,21 @@ class Page(object):
         return selectors[by]
 
     # Public Methods
+
+    def get_element_properties(self, name):
+        """ Given a page element's name, return the configured properties for
+        the element.
+
+        Unless configured otherwise, the returned dictionary will contain a
+        `selector` and `by` attributes. These will contain both the method to
+        select the element and the selector's type.
+
+        Example::
+
+            { 'selector': '//div[@id="top"]/a', 'by': 'xpath' }
+        """
+        return getattr(self._elements, name)
+
 
     @allow_retries(retry_on=(ElementNotFound,), retries=1)
     def find(self, selector, by='id', allow_multiple=False, **kwargs):

--- a/veripy/steps/forms/actions/select_option.py
+++ b/veripy/steps/forms/actions/select_option.py
@@ -2,6 +2,8 @@ import logging
 import splinter.exceptions
 from behave import when
 
+from veripy.exceptions import ImproperlyConfigured
+
 logger = logging.getLogger('forms')
 
 
@@ -21,7 +23,26 @@ def select_option_by(context, value, element_name):
     except context.page.ElementNotFound:
         raise AssertionError(f'The "{element_name}" was not found on the page.')
 
+    properties = context.page.get_element_properties(element_name)
+    by = properties.get('by')
+
+    if by != 'xpath':
+        raise ImproperlyConfigured(
+            f'Cannot select option for select with name "{element_name}". '
+            f'It looks like this element was found using "{by}". '
+            f'Currently only XPaths are supported for this method.'
+        )
+
+    selector = properties['selector']
+
     try:
-        element.select(value)
-    except (AttributeError, IndexError, splinter.exceptions.ElementDoesNotExist):
+        # NOTE: We've elected to not use the provided splinter `select()` method
+        # because it makes the assumption that the select element will have a
+        # `name` attribute which is unfortunately not a sound assumption. In
+        # this case, we just elect to get all of the options that are children
+        # of the select w/o caring about how the select is constructed.
+        element.find_by_xpath(
+            f'{selector}//option[@value="{value}"]'
+        )._element.click()
+    except splinter.exceptions.ElementDoesNotExist:
         raise AssertionError(f'"{element_name}" has no option with value "{value}".')

--- a/veripy/steps/forms/actions/select_option.py
+++ b/veripy/steps/forms/actions/select_option.py
@@ -23,6 +23,28 @@ def select_option_by(context, value, element_name):
     except context.page.ElementNotFound:
         raise AssertionError(f'The "{element_name}" was not found on the page.')
 
+    if element._element.get_attribute('name'):
+        # Default to the preferred Splinter select method.
+        logger.debug(
+            'Select: "{element_name}" has a valid name. Preferring spliter select.'
+        )
+        try:
+            return element.select(value)
+        except (AttributeError, IndexError, splinter.exceptions.ElementDoesNotExist):
+            raise AssertionError(f'"{element_name}" has no option with value "{value}".')
+
+    # In this case, we haven't got a properly formatted <select> element so
+    # we'll attempt to backsolve for its values using XPaths. Splinter
+    # makes the assumption that the select element will have a `name` attribute
+    # which is unfortunately not a sound assumption. In this case, we just elect
+    # to get all of the options that are children of the select w/o caring about
+    # how the select is constructed.
+    #
+    # Note that this method only works if the element was selected by XPath.
+    logger.debug(
+        'Select: "{element_name}" has no name attribute. Trying XPath reversal select method.'
+    )
+
     properties = context.page.get_element_properties(element_name)
     by = properties.get('by')
 
@@ -36,13 +58,8 @@ def select_option_by(context, value, element_name):
     selector = properties['selector']
 
     try:
-        # NOTE: We've elected to not use the provided splinter `select()` method
-        # because it makes the assumption that the select element will have a
-        # `name` attribute which is unfortunately not a sound assumption. In
-        # this case, we just elect to get all of the options that are children
-        # of the select w/o caring about how the select is constructed.
         element.find_by_xpath(
             f'{selector}//option[@value="{value}"]'
         )._element.click()
-    except splinter.exceptions.ElementDoesNotExist:
+    except (AttributeError, IndexError, splinter.exceptions.ElementDoesNotExist):
         raise AssertionError(f'"{element_name}" has no option with value "{value}".')


### PR DESCRIPTION
We've elected to not use the provided splinter `select()` method because it makes the assumption that the select element will have a `name` attribute which is unfortunately not a sound assumption. In this case, we use the select to get all of the options that are children of the select w/o caring about how the select is constructed.

The only limitation of this method is that the select's SELECTOR in the configuration file *MUST* be an XPath. There's no easy way to do this for other selector types w/o lots of weird string manipluation.

## Additions

- Adds a new public method to the Page to allow users to fetch the selector properties by name.
- Adds a new exceptions file and `ImproperlyConfigured` exception for configuration issues. (See Docs)

## Removals

- N/A

## Changes

- Options in selects can now be used even if the select has no name.

## Screenshots

N/A

## Notes

- N/A

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code is rebased
- [x] Code follows the existing coding style guide
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Project documentation has been updated
- [x] Visually tested in supported browsers and devices (if applicable)

